### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,4 +1,6 @@
 name: GitHub-Discord Bridge
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GALAXY-CH/landing-page/security/code-scanning/1](https://github.com/GALAXY-CH/landing-page/security/code-scanning/1)

The best way to fix this issue is to add a `permissions` block with the minimum privileges required for the workflow to function. This is usually done at the workflow root (for all jobs), or at the job level if different jobs require different scopes. In this case, since there is only one job, we can insert it either at the root (above `jobs:`), or specifically for the `bridge` job.

Given the advice, a safe minimal starting point that works for most workflows is:
```yaml
permissions:
  contents: read
```
If the `github-discord-bridge` action requires additional write permissions (e.g., for issues or pull requests), these could later be added granularly. But unless the workflow is known to require them, the least-privilege default (`contents: read`) suffices.

The change should be made to `.github/workflows/discord.yml`, inserting the block directly after the workflow name and before the `on:` key, usually at line 2 or 3.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
