### PR TITLE
Fix Switch Cloud's name

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@
                     <div class="community-icon">💻</div>
                     <h3 class="community-title">Infrastructure</h3>
                     <p class="community-description">
-                        Scalable infrastructure on SWITCH Cloud with HPC integration.
+                        Scalable infrastructure on Switch Cloud with HPC integration.
                     </p>
                 </a>
             </div>


### PR DESCRIPTION
Ref. https://www.switch.ch/en/insights/new-brand-identity-switch:

> [...] the name Switch is no longer written exclusively in capital letters.